### PR TITLE
Schneems/error match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## HEAD (unreleased)
+
+## 0.1.1
+
+- Fix error message detection to fire on more rubies ()
+
+## 0.1.0
+
+- Initial release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    syntax_search (0.1.0)
+    syntax_search (0.1.1)
       parser
 
 GEM

--- a/README.md
+++ b/README.md
@@ -45,9 +45,17 @@ And then execute:
 
     $ bundle install
 
+If your application is not calling `Bundler.require` then you must manually add a require:
+
+```ruby
+require "syntax_search/auto"
+```
+
 To get the CLI and manually search for syntax errors, install the gem:
 
     $ gem install syntax_search
+
+This gives you the CLI command `$ syntax_search` for more info run `$ syntax_search --help`.
 
 ## What does it do?
 

--- a/lib/syntax_search.rb
+++ b/lib/syntax_search.rb
@@ -12,7 +12,7 @@ module SyntaxErrorSearch
   SEARCH_SOURCE_ON_ERROR_DEFAULT = true
 
   def self.handle_error(e, search_source_on_error: SEARCH_SOURCE_ON_ERROR_DEFAULT)
-    raise e if !e.message.include?("expecting end-of-input")
+    raise e if !e.message.include?("end-of-input")
 
     filename = e.message.split(":").first
 

--- a/lib/syntax_search/version.rb
+++ b/lib/syntax_search/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SyntaxErrorSearch
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION

I'm not sure why the tests didn't catch this:

```
  /Users/rschneeman/Documents/projects/work/minimal-ruby/spec/unit/toml_spec.rb:18: syntax error, unexpected end-of-input, expecting `end'
```

It seems circle's error message is different for some reason:

```
/usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require': /tmp/d20201111-79-lhlcok/script.rb:10: syntax error, unexpected `end', expecting end-of-input (SyntaxError)
	from /usr/local/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:92:in `require'
	from /home/circleci/project/lib/syntax_search/auto.rb:26:in `require_relative'
	from /tmp/d20201111-79-lhlcok/require.rb:1:in `<main>'
/tmp/d20201111-79-lhlcok/script.rb:10: syntax error, unexpected `end', expecting end-of-input
```

https://app.circleci.com/pipelines/github/zombocom/syntax_search/28/workflows/8bb184c9-7f04-49ef-8d01-12c0cbc1a810