### PR TITLE
More specific error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## HEAD (unreleased)
 
+- "Unmatched end" and "missing end" not generate different error text instructions (https://github.com/zombocom/syntax_search/pull/10)
+
 ## 0.1.1
 
 - Fire search on both unexpected end-of-input and unexected end (https://github.com/zombocom/syntax_search/pull/8)

--- a/spec/unit/display_invalid_blocks_spec.rb
+++ b/spec/unit/display_invalid_blocks_spec.rb
@@ -42,7 +42,7 @@ module SyntaxErrorSearch
       )
       display.call
       expect(io.string).to include("❯ 2    def hello")
-      expect(io.string).to include("A syntax error was detected")
+      expect(io.string).to include("SyntaxSearch")
     end
 
     it " wraps code with github style codeblocks" do

--- a/spec/unit/exe_spec.rb
+++ b/spec/unit/exe_spec.rb
@@ -22,7 +22,7 @@ module SyntaxErrorSearch
       ruby_file = fixtures_dir.join("this_project_extra_def.rb.txt")
       out = exe("#{ruby_file} --no-terminal")
 
-      expect(out.strip).to include("A syntax error was detected")
+      expect(out.strip).to include("Missing `end` detected")
       expect(out.strip).to include("❯ 36      def filename")
     end
 
@@ -37,7 +37,7 @@ module SyntaxErrorSearch
 
         out = exe("#{ruby_file} --record #{tmp_dir}")
 
-        expect(out.strip).to include("A syntax error was detected")
+        expect(out.strip).to include("Unmatched `end` detected")
         expect(tmp_dir).to_not be_empty
       end
     end

--- a/spec/unit/syntax_search_spec.rb
+++ b/spec/unit/syntax_search_spec.rb
@@ -32,7 +32,7 @@ module SyntaxErrorSearch
 
         out = `ruby -I#{lib_dir} -rsyntax_search/auto #{require_rb} 2>&1`
 
-        expect(out).to include("This code has an unmatched")
+        expect(out).to include("Unmatched `end` detected")
         expect(out).to include("Run `$ syntax_search")
         expect($?.success?).to be_falsey
       end


### PR DESCRIPTION
As mentioned in https://github.com/zombocom/syntax_search/pull/8#issuecomment-725527786 there are two types of syntax errors that can be hit involving an end:

- It's got and end but wasn't expecting one (unmatched end)
- It needs an end but doesn't have one (missing end)

To make this more clear, the output of SyntaxSearch now specializes for these two cases and gives a helpful output with more context.