### PR TITLE
Use indentation code blocks instead of code fences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Codeblocks in output are now indented with 4 spaces and "code fences" are removed (https://github.com/zombocom/syntax_search/pull/11)
 - "Unmatched end" and "missing end" not generate different error text instructions (https://github.com/zombocom/syntax_search/pull/10)
 
 ## 0.1.1

--- a/lib/syntax_search/display_invalid_blocks.rb
+++ b/lib/syntax_search/display_invalid_blocks.rb
@@ -64,16 +64,13 @@ module SyntaxErrorSearch
       EOM
     end
 
-    def indent(string, with: "  ")
+    def indent(string, with: "    ")
       string.each_line.map {|l| with  + l }.join
     end
 
     def code_block
       string = String.new("")
-      string << "```\n"
-      # string << "#".rjust(@digit_count) + " filename: #{filename}\n\n" if filename
       string << code_with_lines
-      string << "```\n"
       string
     end
 

--- a/spec/unit/code_search_spec.rb
+++ b/spec/unit/code_search_spec.rb
@@ -17,7 +17,7 @@ module SyntaxErrorSearch
         search.call
 
         expect(search.record_dir.entries.map(&:to_s)).to include("1-add-1.txt")
-        expect(search.record_dir.join("1-add-1.txt").read).to eq(<<~EOM.indent(2))
+        expect(search.record_dir.join("1-add-1.txt").read).to eq(<<~EOM.indent(4))
             1  class OH
             2    def hello
           ❯ 3    def hai

--- a/spec/unit/display_invalid_blocks_spec.rb
+++ b/spec/unit/display_invalid_blocks_spec.rb
@@ -60,13 +60,11 @@ module SyntaxErrorSearch
         terminal: false
       )
       expect(display.code_block).to eq(<<~EOM)
-       ```
          1  class OH
        ❯ 2    def hello
          3    def hai
          4    end
          5  end
-       ```
       EOM
     end
     it "shows terminal characters" do


### PR DESCRIPTION
When copying and pasting the output to GitHub issues I found that I could not put it inside of code blocks since the output itself has code blocks. To alleviate this we can use indentation to mark the code block instead. This allows us to directly copy and paste the output into GitHub.