### PR TITLE
[changelog skip] Refactor: Immutable CodeBlocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "rspec", "~> 3.0"
+gem "stackprof"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.0)
+    stackprof (0.2.16)
 
 PLATFORMS
   ruby
@@ -32,6 +33,7 @@ PLATFORMS
 DEPENDENCIES
   rake (~> 12.0)
   rspec (~> 3.0)
+  stackprof
   syntax_search!
 
 BUNDLED WITH

--- a/lib/syntax_search.rb
+++ b/lib/syntax_search.rb
@@ -40,6 +40,7 @@ module SyntaxErrorSearch
       blocks: blocks,
       filename: filename,
       terminal: terminal,
+      code_lines: search.code_lines,
       invalid_type: invalid_type(source),
       io: $stderr
     ).call
@@ -152,5 +153,9 @@ end
 require_relative "syntax_search/code_line"
 require_relative "syntax_search/code_block"
 require_relative "syntax_search/code_frontier"
-require_relative "syntax_search/code_search"
 require_relative "syntax_search/display_invalid_blocks"
+require_relative "syntax_search/around_block_scan"
+require_relative "syntax_search/block_expand"
+require_relative "syntax_search/parse_blocks_from_indent_line"
+
+require_relative "syntax_search/code_search"

--- a/lib/syntax_search/around_block_scan.rb
+++ b/lib/syntax_search/around_block_scan.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+#
+module SyntaxErrorSearch
+  # This class is useful for exploring contents before and after
+  # a block
+  #
+  # It searches above and below the passed in block to match for
+  # whatever criteria you give it:
+  #
+  # Example:
+  #
+  #   def dog
+  #     puts "bark"
+  #     puts "bark"
+  #   end
+  #
+  #   scan = AroundBlockScan.new(
+  #     code_lines: code_lines
+  #     block: CodeBlock.new(lines: code_lines[1])
+  #   )
+  #
+  #   scan.scan_while { true }
+  #
+  #   puts scan.before_index # => 0
+  #   puts scan.after_index # => 3
+  #
+  # Contents can also be filtered using AroundBlockScan#skip
+  #
+  # To grab the next surrounding indentation use AroundBlockScan#scan_adjacent_indent
+  class AroundBlockScan
+    def initialize(code_lines: , block:)
+      @code_lines = code_lines
+      @orig_before_index = block.lines.first.index
+      @orig_after_index = block.lines.last.index
+      @skip_array = []
+      @after_array = []
+      @before_array = []
+    end
+
+    def skip(name)
+      @skip_array << name
+      self
+    end
+
+    def scan_while(&block)
+      @before_index = before_lines.reverse_each.take_while do |line|
+        next true if @skip_array.detect {|meth| line.send(meth) }
+
+        block.call(line)
+      end.reverse.first&.index
+
+      @after_index = after_lines.take_while do |line|
+        next true if @skip_array.detect {|meth| line.send(meth) }
+
+        block.call(line)
+      end.last&.index
+      self
+    end
+
+    def scan_adjacent_indent
+      before_indent = @code_lines[@orig_before_index.pred]&.indent || 0
+      after_indent = @code_lines[@orig_after_index.next]&.indent || 0
+
+      indent = [before_indent, after_indent].min
+      @before_index = before_index.pred if before_indent >= indent
+      @after_index = after_index.next if after_indent >= indent
+
+      self
+    end
+
+    def code_block
+      CodeBlock.new(lines: @code_lines[before_index..after_index])
+    end
+
+    def before_index
+      @before_index || @orig_before_index
+    end
+
+    def after_index
+      @after_index || @orig_after_index
+    end
+
+    private def before_lines
+      @code_lines[0...@orig_before_index]
+    end
+
+    private def after_lines
+      @code_lines[@orig_after_index.next..-1]
+    end
+  end
+end

--- a/lib/syntax_search/block_expand.rb
+++ b/lib/syntax_search/block_expand.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+module SyntaxErrorSearch
+  # This class is responsible for taking a code block that exists
+  # at a far indentaion and then iteratively increasing the block
+  # so that it captures everything within the same indentation block.
+  #
+  #   def dog
+  #     puts "bow"
+  #     puts "wow"
+  #   end
+  #
+  # block = BlockExpand.new(code_lines: code_lines)
+  #   .call(CodeBlock.new(lines: code_lines[1]))
+  #
+  # puts block.to_s
+  # # => puts "bow"
+  #      puts "wow"
+  #
+  #
+  # Once a code block has captured everything at a given indentation level
+  # then it will expand to capture surrounding indentation.
+  #
+  # block = BlockExpand.new(code_lines: code_lines)
+  #   .call(block)
+  #
+  # block.to_s
+  # # => def dog
+  #        puts "bow"
+  #        puts "wow"
+  #      end
+  #
+  class BlockExpand
+    def initialize(code_lines: )
+      @code_lines = code_lines
+    end
+
+    def call(block)
+      if (next_block = expand_neighbors(block, grab_empty: true))
+        return next_block
+      end
+
+      expand_indent(block)
+    end
+
+    def expand_indent(block)
+      block = AroundBlockScan.new(code_lines: @code_lines, block: block)
+        .scan_adjacent_indent
+        .code_block
+
+      # Handle if/else/end case
+      if (next_block = expand_neighbors(block, grab_empty: false))
+        return next_block
+      else
+        return block
+      end
+    end
+
+    def expand_neighbors(block, grab_empty: true)
+      scan = AroundBlockScan.new(code_lines: @code_lines, block: block)
+        .skip(:hidden?)
+        .scan_while {|line| line.not_empty? && line.indent >= block.current_indent }
+
+      # Slurp up empties
+      if grab_empty
+        scan = AroundBlockScan.new(code_lines: @code_lines, block: scan.code_block)
+          .scan_while {|line| line.empty? || line.hidden? }
+      end
+
+      new_block = scan.code_block
+
+      if block.lines == new_block.lines
+        return nil
+      else
+        return new_block
+      end
+    end
+  end
+end

--- a/lib/syntax_search/code_block.rb
+++ b/lib/syntax_search/code_block.rb
@@ -3,11 +3,7 @@
 module SyntaxErrorSearch
   # Multiple lines form a singular CodeBlock
   #
-  # Source code is made of multiple CodeBlocks. A code block
-  # has a reference to the source code that created itself, this allows
-  # a code block to "expand" when needed
-  #
-  # The most important ability of a CodeBlock is this ability to expand:
+  # Source code is made of multiple CodeBlocks.
   #
   # Example:
   #
@@ -16,21 +12,19 @@ module SyntaxErrorSearch
   #     #     puts "foo"
   #     #   end
   #
-  #   code_block.expand_until_next_boundry
+  #   code_block.valid? # => true
+  #   code_block.in_valid? # => false
   #
-  #   code_block.to_s # =>
-  #     # class Foo
-  #     #   def foo
-  #     #     puts "foo"
-  #     #   end
-  #     # end
   #
   class CodeBlock
     attr_reader :lines
 
-    def initialize(code_lines: nil, lines: [])
+    def initialize(lines: [])
       @lines = Array(lines)
-      @code_lines = code_lines
+    end
+
+    def mark_invisible
+      @lines.map(&:mark_invisible)
     end
 
     def is_end?
@@ -38,11 +32,11 @@ module SyntaxErrorSearch
     end
 
     def starts_at
-      @lines.first&.line_number
+      @starts_at ||= @lines.first&.line_number
     end
 
-    def code_lines
-      @code_lines
+    def ends_at
+      @ends_at ||= @lines.last&.line_number
     end
 
     # This is used for frontier ordering, we are searching from
@@ -53,155 +47,8 @@ module SyntaxErrorSearch
       self.current_indent <=> other.current_indent
     end
 
-    # Only the lines that are not empty and visible
-    def visible_lines
-      @lines
-        .select(&:not_empty?)
-        .select(&:visible?)
-    end
-
-    # This method is used to expand a code block to capture it's calling context
-    def expand_until_next_boundry
-      expand_to_indent(next_indent)
-      self
-    end
-
-    # This method expands the given code block until it captures
-    # its nearest neighbors. This is used to expand a single line of code
-    # to its smallest likely block.
-    #
-    #   code_block.to_s # =>
-    #     #     puts "foo"
-    #   code_block.expand_until_neighbors
-    #
-    #   code_block.to_s # =>
-    #     #     puts "foo"
-    #     #     puts "bar"
-    #     #     puts "baz"
-    #
-    def expand_until_neighbors
-      expand_to_indent(current_indent)
-
-      expand_hidden_parner_line if self.to_s.strip == "end"
-      self
-    end
-
-    def expand_hidden_parner_line
-      index = @lines.first.index
-      indent = current_indent
-      partner_line  = code_lines.select {|line| line.index < index && line.indent == indent }.last
-
-      if partner_line&.hidden?
-        partner_line.mark_visible
-        @lines.prepend(partner_line)
-      end
-    end
-
-    # This method expands the existing code block up (before)
-    # and down (after). It will break on change in indentation
-    # and empty lines.
-    #
-    #   code_block.to_s # =>
-    #     #   def foo
-    #     #     puts "foo"
-    #     #   end
-    #
-    #   code_block.expand_to_indent(0)
-    #   code_block.to_s # =>
-    #     # class Foo
-    #     #   def foo
-    #     #     puts "foo"
-    #     #   end
-    #     # end
-    #
-    private def expand_to_indent(indent)
-      array = []
-      before_lines(skip_empty: false).each do |line|
-        if line.empty?
-          array.prepend(line)
-          break
-        end
-
-        if line.indent == indent
-          array.prepend(line)
-        else
-          break
-        end
-      end
-
-      array << @lines
-
-      after_lines(skip_empty: false).each do |line|
-        if line.empty?
-          array << line
-          break
-        end
-
-        if line.indent == indent
-          array << line
-        else
-          break
-        end
-      end
-
-      @lines = array.flatten
-    end
-
-    def next_indent
-      [
-        before_line&.indent || 0,
-        after_line&.indent || 0
-      ].max
-    end
-
     def current_indent
-      lines.detect(&:not_empty?)&.indent || 0
-    end
-
-    def before_line
-      before_lines.first
-    end
-
-    def after_line
-      after_lines.first
-    end
-
-    def before_lines(skip_empty: true)
-      index = @lines.first.index
-      lines = code_lines.select {|line| line.index < index }
-      lines.select!(&:not_empty?) if skip_empty
-      lines.select!(&:visible?)
-      lines.reverse!
-
-      lines
-    end
-
-    def after_lines(skip_empty: true)
-      index = @lines.last.index
-      lines = code_lines.select {|line| line.index > index }
-      lines.select!(&:not_empty?) if skip_empty
-      lines.select!(&:visible?)
-      lines
-    end
-
-    # Returns a code block of the source that does not include
-    # the current lines. This is useful for checking if a source
-    # with the given lines removed parses successfully. If so
-    #
-    # Then it's proof that the current block is invalid
-    def block_without
-      @block_without ||= CodeBlock.new(
-        source: @source,
-        lines: @source.code_lines - @lines
-      )
-    end
-
-    def document_valid_without?
-      block_without.valid?
-    end
-
-    def valid_without?
-      block_without.valid?
+      @current_indent ||= lines.select(&:not_empty?).map(&:indent).min || 0
     end
 
     def invalid?

--- a/lib/syntax_search/display_invalid_blocks.rb
+++ b/lib/syntax_search/display_invalid_blocks.rb
@@ -5,14 +5,14 @@ module SyntaxErrorSearch
   class DisplayInvalidBlocks
     attr_reader :filename
 
-    def initialize(blocks:, io: $stderr, filename: nil, terminal: false, invalid_type: :unmatched_end)
+    def initialize(code_lines: ,blocks:, io: $stderr, filename: nil, terminal: false, invalid_type: :unmatched_end)
       @terminal = terminal
       @filename = filename
       @io = io
 
       @blocks = Array(blocks)
       @lines = @blocks.map(&:lines).flatten
-      @code_lines = @blocks.first&.code_lines || []
+      @code_lines = code_lines
       @digit_count = @code_lines.last&.line_number.to_s.length
 
       @invalid_line_hash = @lines.each_with_object({}) {|line, h| h[line] = true  }

--- a/lib/syntax_search/parse_blocks_from_indent_line.rb
+++ b/lib/syntax_search/parse_blocks_from_indent_line.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module SyntaxErrorSearch
+  # This class is responsible for generating initial code blocks
+  # that will then later be expanded.
+  #
+  # The biggest concern when guessing about code blocks, is accidentally
+  # grabbing one that contains only an "end". In this example:
+  #
+  #   def dog
+  #     begonn # mispelled `begin`
+  #     puts "bark"
+  #     end
+  #   end
+  #
+  # The following lines would be matched (from bottom to top):
+  #
+  #   1) end
+  #
+  #   2) puts "bark"
+  #      end
+  #
+  #   3) begonn
+  #      puts "bark"
+  #      end
+  #
+  # At this point it has no where else to expand, and it will yield this inner
+  # code as a block
+  class ParseBlocksFromIndentLine
+    attr_reader :code_lines
+
+    def initialize(code_lines: )
+      @code_lines = code_lines
+    end
+
+    # Builds blocks from bottom up
+    def each_neighbor_block(target_line)
+      scan = AroundBlockScan.new(code_lines: code_lines, block: CodeBlock.new(lines: target_line))
+        .skip(:empty?)
+        .skip(:hidden?)
+        .scan_while {|line| line.indent >= target_line.indent }
+
+      neighbors = @code_lines[scan.before_index..scan.after_index]
+
+      until neighbors.empty?
+        lines = [neighbors.pop]
+        while (block = CodeBlock.new(lines: lines)) && block.invalid? && neighbors.any?
+          lines.prepend neighbors.pop
+        end
+
+        yield block if block
+      end
+    end
+  end
+end
+

--- a/spec/unit/around_block_scan_spec.rb
+++ b/spec/unit/around_block_scan_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module SyntaxErrorSearch
+  RSpec.describe AroundBlockScan do
+    it "captures multiple empty and hidden lines" do
+      source_string = <<~EOM
+        def foo
+          Foo.call
+
+            puts "lol"
+
+          end
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+      block = CodeBlock.new(lines: code_lines[3])
+      expand = AroundBlockScan.new(code_lines: code_lines, block: block)
+      expand.scan_while { true }
+
+      expect(expand.before_index).to eq(0)
+      expect(expand.after_index).to eq(6)
+      expect(expand.code_block.to_s).to eq(source_string)
+    end
+
+    it "only takes what you ask" do
+      source_string = <<~EOM
+        def foo
+          Foo.call
+
+            puts "lol"
+
+          end
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+      block = CodeBlock.new(lines: code_lines[3])
+      expand = AroundBlockScan.new(code_lines: code_lines, block: block)
+      expand.scan_while {|line| line.not_empty? }
+
+      expect(expand.code_block.to_s).to eq(<<~EOM.indent(4))
+        puts "lol"
+      EOM
+    end
+
+    it "skips what you want" do
+      source_string = <<~EOM
+        def foo
+          Foo.call
+
+            puts "haha"
+            # hide me
+
+            puts "lol"
+
+          end
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+      code_lines[4].mark_invisible
+
+      block = CodeBlock.new(lines: code_lines[3])
+      expand = AroundBlockScan.new(code_lines: code_lines, block: block)
+      expand.skip(:empty?)
+      expand.skip(:hidden?)
+      expand.scan_while {|line| line.indent >= block.current_indent }
+
+      expect(expand.code_block.to_s).to eq(<<~EOM.indent(4))
+
+        puts "haha"
+
+        puts "lol"
+
+      EOM
+    end
+  end
+end

--- a/spec/unit/block_expand_spec.rb
+++ b/spec/unit/block_expand_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+
+module SyntaxErrorSearch
+
+  RSpec.describe BlockExpand do
+    it "captures multiple empty and hidden lines" do
+      source_string = <<~EOM
+        def foo
+          Foo.call
+
+
+            puts "lol"
+
+            # hidden
+          end
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+
+      code_lines[6].mark_invisible
+
+      block = CodeBlock.new(lines: [code_lines[3]])
+      expansion = BlockExpand.new(code_lines: code_lines)
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM.indent(4))
+
+
+        puts "lol"
+
+      EOM
+    end
+
+    it "captures multiple empty lines" do
+      source_string = <<~EOM
+        def foo
+          Foo.call
+
+
+            puts "lol"
+
+          end
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+      block = CodeBlock.new(lines: [code_lines[3]])
+      expansion = BlockExpand.new(code_lines: code_lines)
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM.indent(4))
+
+
+        puts "lol"
+
+      EOM
+    end
+
+    it "expands neighbors then indentation" do
+      source_string = <<~EOM
+        def foo
+          Foo.call
+            puts "hey"
+            puts "lol"
+            puts "sup"
+          end
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+      block = CodeBlock.new(lines: [code_lines[3]])
+      expansion = BlockExpand.new(code_lines: code_lines)
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM.indent(4))
+        puts "hey"
+        puts "lol"
+        puts "sup"
+      EOM
+
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM.indent(2))
+        Foo.call
+          puts "hey"
+          puts "lol"
+          puts "sup"
+        end
+      EOM
+    end
+
+    it "handles else code" do
+      source_string = <<~EOM
+        Foo.call
+          if blerg
+            puts "lol"
+          else
+            puts "haha"
+          end
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+      block = CodeBlock.new(lines: [code_lines[2]])
+      expansion = BlockExpand.new(code_lines: code_lines)
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM.indent(2))
+        if blerg
+          puts "lol"
+        else
+          puts "haha"
+        end
+      EOM
+
+      block = expansion.call(block)
+    end
+
+    it "expand until next boundry (indentation)" do
+      source_string = <<~EOM
+        describe "what" do
+          Foo.call
+        end
+
+        describe "hi"
+          Bar.call do
+            Foo.call
+          end
+        end
+
+        it "blerg" do
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+
+      block = CodeBlock.new(
+        lines: code_lines[6]
+      )
+
+      expansion = BlockExpand.new(code_lines: code_lines)
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM.indent(2))
+        Bar.call do
+          Foo.call
+        end
+      EOM
+
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM)
+        describe "hi"
+          Bar.call do
+            Foo.call
+          end
+        end
+      EOM
+    end
+
+
+    it "expand until next boundry (empty lines)" do
+      source_string = <<~EOM
+        describe "what" do
+        end
+
+        describe "hi"
+        end
+
+        it "blerg" do
+        end
+      EOM
+
+      code_lines = code_line_array(source_string)
+      expansion = BlockExpand.new(code_lines: code_lines)
+
+      block = CodeBlock.new(lines: code_lines[3])
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM)
+
+        describe "hi"
+        end
+
+      EOM
+
+      block = expansion.call(block)
+
+      expect(block.to_s).to eq(<<~EOM)
+        describe "what" do
+        end
+
+        describe "hi"
+        end
+
+        it "blerg" do
+        end
+      EOM
+    end
+  end
+end

--- a/spec/unit/code_block_spec.rb
+++ b/spec/unit/code_block_spec.rb
@@ -4,130 +4,6 @@ require_relative "../spec_helper.rb"
 
 module SyntaxErrorSearch
   RSpec.describe CodeBlock do
-
-    it "expand until next boundry (indentation)" do
-      source_string = <<~EOM
-        def foo
-          Foo.call
-          end
-        end
-      EOM
-
-      code_lines = code_line_array(source_string)
-
-      scan = IndentScan.new(code_lines: code_lines)
-      neighbors = scan.neighbors_from_top(code_lines[1])
-
-      block = CodeBlock.new(
-        lines: neighbors.last,
-        code_lines: code_lines
-      )
-
-      expect(block.valid?).to be_falsey
-      expect(block.to_s).to eq(<<~EOM.indent(2))
-        end
-      EOM
-
-      frontier = []
-
-      scan.each_neighbor_block(code_lines[1]) do |block|
-        if block.valid?
-          block.lines.map(&:mark_valid)
-        else
-          frontier << block
-        end
-      end
-
-      expect(frontier.join).to eq(<<~EOM.indent(2))
-        Foo.call
-        end
-      EOM
-    end
-
-    it "expand until next boundry (indentation)" do
-      source_string = <<~EOM
-        describe "what" do
-          Foo.call
-        end
-
-        describe "hi"
-          Bar.call do
-            Foo.call
-          end
-        end
-
-        it "blerg" do
-        end
-      EOM
-
-      code_lines = code_line_array(source_string)
-
-      block = CodeBlock.new(
-        lines: code_lines[6],
-        code_lines: code_lines
-      )
-
-      block.expand_until_next_boundry
-
-      expect(block.to_s).to eq(<<~EOM.indent(2))
-        Bar.call do
-          Foo.call
-        end
-      EOM
-
-      block.expand_until_next_boundry
-
-      expect(block.to_s).to eq(<<~EOM)
-
-        describe "hi"
-          Bar.call do
-            Foo.call
-          end
-        end
-
-      EOM
-    end
-
-    it "expand until next boundry (empty lines)" do
-      source_string = <<~EOM
-        describe "what" do
-        end
-
-        describe "hi"
-        end
-
-        it "blerg" do
-        end
-      EOM
-
-      code_lines = code_line_array(source_string)
-      block = CodeBlock.new(
-        lines: code_lines[0],
-        code_lines: code_lines
-      )
-      block.expand_until_next_boundry
-
-      expect(block.to_s.strip).to eq(<<~EOM.strip)
-        describe "what" do
-        end
-      EOM
-
-      block = CodeBlock.new(
-        lines: code_lines[3],
-        code_lines: code_lines
-      )
-      block.expand_until_next_boundry
-
-      expect(block.to_s.strip).to eq(<<~EOM.strip)
-        describe "hi"
-        end
-      EOM
-
-      block.expand_until_next_boundry
-
-      expect(block.to_s.strip).to eq(source_string.strip)
-    end
-
     it "can detect if it's valid or not" do
       code_lines = code_line_array(<<~EOM)
         def foo
@@ -135,7 +11,7 @@ module SyntaxErrorSearch
         end
       EOM
 
-      block = CodeBlock.new(code_lines: code_lines, lines: code_lines[1])
+      block = CodeBlock.new(lines: code_lines[1])
       expect(block.valid?).to be_truthy
     end
 
@@ -146,9 +22,9 @@ module SyntaxErrorSearch
             end
       EOM
 
-      block_0 = CodeBlock.new(code_lines: code_lines, lines: code_lines[0])
-      block_1 = CodeBlock.new(code_lines: code_lines, lines: code_lines[1])
-      block_2 = CodeBlock.new(code_lines: code_lines, lines: code_lines[2])
+      block_0 = CodeBlock.new(lines: code_lines[0])
+      block_1 = CodeBlock.new(lines: code_lines[1])
+      block_2 = CodeBlock.new(lines: code_lines[2])
 
       expect(block_0 <=> block_0).to eq(0)
       expect(block_1 <=> block_0).to eq(1)
@@ -157,7 +33,7 @@ module SyntaxErrorSearch
       array = [block_2, block_1, block_0].sort
       expect(array.last).to eq(block_2)
 
-      block = CodeBlock.new(code_lines: code_lines, lines: CodeLine.new(line: " " * 8 + "foo", index: 4))
+      block = CodeBlock.new(lines: CodeLine.new(line: " " * 8 + "foo", index: 4))
       array.prepend(block)
       expect(array.sort.last).to eq(block)
     end
@@ -169,17 +45,23 @@ module SyntaxErrorSearch
         end
       EOM
 
-      block = CodeBlock.new(code_lines: code_lines, lines: code_lines[1])
+      block = CodeBlock.new(lines: code_lines[1])
       expect(block.current_indent).to eq(2)
-      expect(block.before_lines).to eq([code_lines[0]])
-      expect(block.before_line).to eq(code_lines[0])
-      expect(block.after_lines).to eq([code_lines[2]])
-      expect(block.after_line).to eq(code_lines[2])
 
-      block = CodeBlock.new(code_lines: code_lines, lines: code_lines[0])
+      block = CodeBlock.new(lines: code_lines[0])
       expect(block.current_indent).to eq(0)
     end
 
+    it "knows it's current indentation level when mismatched indents" do
+      code_lines = code_line_array(<<~EOM)
+        def foo
+          puts 'lol'
+         end
+      EOM
+
+      block = CodeBlock.new(lines: [code_lines[1], code_lines[2]])
+      expect(block.current_indent).to eq(1)
+    end
 
     it "before lines and after lines" do
       code_lines = code_line_array(<<~EOM)
@@ -188,10 +70,8 @@ module SyntaxErrorSearch
         end
       EOM
 
-      block = CodeBlock.new(code_lines: code_lines, lines: code_lines[1])
+      block = CodeBlock.new(lines: code_lines[1])
       expect(block.valid?).to be_falsey
-      expect(block.before_lines).to eq([code_lines[0]])
-      expect(block.after_lines).to eq([code_lines[2]])
     end
   end
 end

--- a/spec/unit/display_invalid_blocks_spec.rb
+++ b/spec/unit/display_invalid_blocks_spec.rb
@@ -14,11 +14,14 @@ module SyntaxErrorSearch
         end
       EOM
 
+      search = CodeSearch.new(syntax_string)
+      search.call
       io = StringIO.new
       display = DisplayInvalidBlocks.new(
-        blocks: CodeSearch.new(syntax_string).call.invalid_blocks,
+        io: io,
+        blocks: search.invalid_blocks,
         terminal: false,
-        io: io
+        code_lines: search.code_lines,
       )
       display.call
       expect(io.string).to include("Syntax OK")
@@ -34,11 +37,12 @@ module SyntaxErrorSearch
       EOM
 
       io = StringIO.new
-      block = CodeBlock.new(code_lines: code_lines, lines: code_lines[1])
+      block = CodeBlock.new(lines: code_lines[1])
       display = DisplayInvalidBlocks.new(
+        io: io,
         blocks: block,
         terminal: false,
-        io: io
+        code_lines: code_lines,
       )
       display.call
       expect(io.string).to include("❯ 2    def hello")
@@ -54,10 +58,11 @@ module SyntaxErrorSearch
         end
       EOM
 
-      block = CodeBlock.new(code_lines: code_lines, lines: code_lines[1])
+      block = CodeBlock.new(lines: code_lines[1])
       display = DisplayInvalidBlocks.new(
         blocks: block,
-        terminal: false
+        terminal: false,
+        code_lines: code_lines
       )
       expect(display.code_block).to eq(<<~EOM)
          1  class OH
@@ -76,10 +81,11 @@ module SyntaxErrorSearch
         end
       EOM
 
-      block = CodeBlock.new(code_lines: code_lines, lines: code_lines[1])
+      block = CodeBlock.new(lines: code_lines[1])
       display = DisplayInvalidBlocks.new(
         blocks: block,
-        terminal: false
+        terminal: false,
+        code_lines: code_lines
       )
 
       expect(display.code_with_lines).to eq(
@@ -93,10 +99,11 @@ module SyntaxErrorSearch
         ].join($/)
       )
 
-      block = CodeBlock.new(code_lines: code_lines, lines: code_lines[1])
+      block = CodeBlock.new(lines: code_lines[1])
       display = DisplayInvalidBlocks.new(
         blocks: block,
-        terminal: true
+        terminal: true,
+        code_lines: code_lines
       )
 
       expect(display.code_with_lines).to eq(


### PR DESCRIPTION
To be able to have CodeBlock class not depend on knowledge of all code lines, we need to move the code expansion logic outside of the code class.

It's now being represented in the BlockExpand class which can be independently tested. To simplify writing this class, a helper class AroundBlockScan was introduced. This class automates some of the chores around searching before/after a given block.

The IndentScan class has been renamed to ParseBlocksFromIndentLine to be a little more descriptive about it's purpose and goal, but I'm still struggling to name it.