### PR TITLE
[close #16] Replace Parser with Ripper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (unreleased)
 
+## 0.1.4
+
+- Parser gem replaced with Ripper (https://github.com/zombocom/syntax_search/pull/17)
+
 ## 0.1.3
 
 - Internal refactor (https://github.com/zombocom/syntax_search/pull/13)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,12 @@
 PATH
   remote: .
   specs:
-    syntax_search (0.1.3)
-      parser
+    syntax_search (0.1.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.1)
     diff-lcs (1.4.4)
-    parser (2.7.2.0)
-      ast (~> 2.4.1)
     rake (12.3.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)

--- a/lib/syntax_search/version.rb
+++ b/lib/syntax_search/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SyntaxErrorSearch
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/lib/syntax_search/who_dis_syntax_error.rb
+++ b/lib/syntax_search/who_dis_syntax_error.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module SyntaxErrorSearch
+  # Determines what type of syntax error is in the source
+  #
+  # Example:
+  #
+  #   puts WhoDisSyntaxError.new("def foo;").call.error_symbol
+  #   # => :missing_end
+  class WhoDisSyntaxError < Ripper
+    attr_reader :error, :run_once, :error_symbol
+
+    def call
+      @run_once ||= begin
+        parse
+        true
+      end
+      self
+    end
+
+    def on_parse_error(msg)
+      @error = msg
+      if @error.match?(/unexpected end-of-input/)
+        @error_symbol = :missing_end
+      elsif @error.match?(/unexpected `end'/) || @error.match?(/expecting end-of-input/)
+        @error_symbol = :unmatched_end
+      else
+        @error_symbol = :nope
+      end
+    end
+  end
+end

--- a/spec/unit/who_dis_syntax_error_spec.rb
+++ b/spec/unit/who_dis_syntax_error_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "../spec_helper.rb"
+
+module SyntaxErrorSearch
+  RSpec.describe WhoDisSyntaxError do
+    it  "determines the type of syntax error" do
+      expect(
+        WhoDisSyntaxError.new("def foo;").call.error_symbol
+      ).to eq(:missing_end)
+
+      expect(
+        WhoDisSyntaxError.new("def foo; end; end").call.error_symbol
+      ).to eq(:unmatched_end)
+    end
+  end
+end

--- a/syntax_search.gemspec
+++ b/syntax_search.gemspec
@@ -25,6 +25,4 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  spec.add_dependency "parser"
 end


### PR DESCRIPTION
Ripper is the built in parsing library from Ruby. It is much faster than Parser and it has everything we need.

This PR replaces the parser gem with ripper.