### PR TITLE
[Close #22] Lines are lexically aware of keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## HEAD (unreleased)
 
+- Block expansion is now lexically aware of keywords (def/do/end etc.) (https://github.com/zombocom/syntax_search/pull/24)
 - Fix bug where not all of a source is lexed which is used in heredoc detection/removal (https://github.com/zombocom/syntax_search/pull/23)
 
 ## 0.1.5

--- a/exe/syntax_search
+++ b/exe/syntax_search
@@ -62,6 +62,7 @@ if file.nil? || file.empty?
 end
 
 file = Pathname(file)
+options[:record_dir] = "tmp" if ENV["DEBUG"]
 
 $stderr.puts "Record dir: #{options[:record_dir]}"  if options[:record_dir]
 

--- a/lib/syntax_search/block_expand.rb
+++ b/lib/syntax_search/block_expand.rb
@@ -44,21 +44,16 @@ module SyntaxErrorSearch
 
     def expand_indent(block)
       block = AroundBlockScan.new(code_lines: @code_lines, block: block)
+        .stop_after_kw
         .scan_adjacent_indent
         .code_block
-
-      # Handle if/else/end case
-      if (next_block = expand_neighbors(block, grab_empty: false))
-        return next_block
-      else
-        return block
-      end
     end
 
     def expand_neighbors(block, grab_empty: true)
       scan = AroundBlockScan.new(code_lines: @code_lines, block: block)
         .skip(:hidden?)
-        .scan_while {|line| line.not_empty? && line.indent >= block.current_indent }
+        .stop_after_kw
+        .scan_neighbors
 
       # Slurp up empties
       if grab_empty

--- a/lib/syntax_search/code_line.rb
+++ b/lib/syntax_search/code_line.rb
@@ -39,6 +39,37 @@ module SyntaxErrorSearch
       @indent = SpaceCount.indent(line)
       @status = nil # valid, invalid, unknown
       @invalid = false
+
+      @kw_count = 0
+      @end_count = 0
+      @lex = LexAll.new(source: line)
+      @lex.each do |lex|
+        next unless lex.type == :on_kw
+
+        case lex.token
+        when 'def', 'case', 'for', 'begin', 'class', 'module', 'if', 'unless', 'while', 'until' , 'do'
+          @kw_count += 1
+        when 'end'
+          @end_count += 1
+        end
+      end
+
+      @is_comment = true if @lex.detect {|lex| lex.type != :on_sp}&.type == :on_comment
+
+      @is_kw = (@kw_count - @end_count) > 0
+      @is_end = (@end_count - @kw_count) > 0
+    end
+
+    def is_comment?
+      @is_comment
+    end
+
+    def is_kw?
+      @is_kw
+    end
+
+    def is_end?
+      @is_end
     end
 
     def mark_invalid

--- a/lib/syntax_search/code_search.rb
+++ b/lib/syntax_search/code_search.rb
@@ -108,7 +108,6 @@ module SyntaxErrorSearch
       push(block, name: "expand")
     end
 
-
     def sweep_heredocs
       HeredocBlockParse.new(
         source: @source,
@@ -118,9 +117,16 @@ module SyntaxErrorSearch
       end
     end
 
+    def sweep_comments
+      @code_lines.select(&:is_comment?).each do |line|
+        line.mark_invisible
+      end
+    end
+
     # Main search loop
     def call
       sweep_heredocs
+      sweep_comments
       until frontier.holds_all_syntax_errors?
         @tick += 1
 

--- a/lib/syntax_search/code_search.rb
+++ b/lib/syntax_search/code_search.rb
@@ -28,7 +28,7 @@ module SyntaxErrorSearch
     private; attr_reader :frontier; public
     public; attr_reader :invalid_blocks, :record_dir, :code_lines
 
-    def initialize(source, record_dir: ENV["SYNTAX_SEARCH_RECORD_DIR"])
+    def initialize(source, record_dir: ENV["SYNTAX_SEARCH_RECORD_DIR"] || ENV["DEBUG"] ? "tmp" : nil)
       @source = source
       if record_dir
         @time = Time.now.strftime('%Y-%m-%d-%H-%M-%s-%N')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 require "bundler/setup"
 require "syntax_search"
 
+require 'tempfile'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/unit/code_line_spec.rb
+++ b/spec/unit/code_line_spec.rb
@@ -4,6 +4,29 @@ require_relative "../spec_helper.rb"
 
 module SyntaxErrorSearch
   RSpec.describe CodeLine do
+    it "knows it's a comment" do
+      line = CodeLine.new(line: "   # iama comment", index: 0)
+      expect(line.is_comment?).to be_truthy
+      expect(line.is_end?).to be_falsey
+      expect(line.is_kw?).to be_falsey
+    end
+
+    it "knows it's got an end" do
+      line = CodeLine.new(line: "   end", index: 0)
+
+      expect(line.is_comment?).to be_falsey
+      expect(line.is_end?).to be_truthy
+      expect(line.is_kw?).to be_falsey
+    end
+
+    it "knows it's got a keyword" do
+      line = CodeLine.new(line: "  if", index: 0)
+
+      expect(line.is_comment?).to be_falsey
+      expect(line.is_end?).to be_falsey
+      expect(line.is_kw?).to be_truthy
+    end
+
     it  "can be marked as invalid or valid" do
       code_lines = code_line_array(<<~EOM)
         def foo

--- a/spec/unit/exe_spec.rb
+++ b/spec/unit/exe_spec.rb
@@ -27,20 +27,16 @@ module SyntaxErrorSearch
     end
 
     it "handles heredocs" do
-      Dir.mktmpdir do |dir|
-        dir = Pathname(dir)
+      Tempfile.create do |file|
         lines = fixtures_dir.join("rexe.rb").read.lines
         lines.delete_at(85 - 1)
 
-        ruby_file = dir.join("tmp.rb")
-        ruby_file.write(lines.join)
+        Pathname(file.path).write(lines.join)
 
-        out = exe("#{ruby_file} --no-terminal")
+        out = exe("#{file.path} --no-terminal")
         expect(out.strip).to include(<<~EOM.indent(4))
              77    class Lookups
           ❯  78      def input_modes
-          ❯  87      def input_formats
-          ❯  94      end
         EOM
       end
     end


### PR DESCRIPTION
CodeLines are now lexically aware of keywords. This is used by the AroundBlockScan to allow stopping after a keyword has been hit.

In addition to stripping heredocs before searching, the CodeSearch now also strips lines that contain only comments. The combination of stripping heredocs and comments prevents false positives from lexing individual lines (since a comment might contain valid code i.e. `# def foo; end`. 

New APIs:

- CodeLine#is_comment?
- CodeLine#is_kw?
- CodeLine#is_end?
- AroundBlockScan.stop_after_kw
- AroundBlockScan.scan_neighbors